### PR TITLE
force reload upon clicking back button

### DIFF
--- a/server/views/admin/upload/index.ejs
+++ b/server/views/admin/upload/index.ejs
@@ -32,5 +32,17 @@
       <% } %>
     </table>
     <hr>
+    <input type="hidden" id="refreshed" value="no">
+    <script type="text/javascript">
+      onload=function(){
+        var e=document.getElementById("refreshed");
+        if(e.value=="no"){
+          e.value="yes";
+        }
+        else{
+          e.value="no";location.reload();
+        }
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Issue:
  After clicking "View" for a file in upload page, user is taken to page showing the file. Upon clicking "back" button, user is shown a cached version of the previous page, which does not show the file additions by AJAX. User must click "refresh" button for display to work correctly.
Fix:
  Added code snippet to force page refresh after coming back to upload page.