### PR TITLE
eventbrite widget on events page as an example

### DIFF
--- a/server/views/events.ejs
+++ b/server/views/events.ejs
@@ -84,7 +84,9 @@
 				<div class="col-md-8 col-md-offset-2 text-left fh5co-heading  animate-box">
 					<span>Expand your network</span>
 					<h2>UPCOMING EVENTS</h2>
-					<p>Dignissimos asperiores vitae velit veniam totam fuga molestias accusamus alias autem provident. Odit ab aliquam dolor eius.</p>
+					<!-- Eventbrite Widget -->
+					<div style="width:100%; text-align:left;" ><iframe  src="https://www.eventbrite.com/e/ypc-february-mixer-tickets-31189465531?ref=eweb" frameborder="0" height="1000" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/">Powered by Eventbrite</a></div></div>
+					<!-- . -->
 				</div>
 			</div>
 			<hr>


### PR DESCRIPTION
Generated a widget from YPC eventbrite profile. This is an example of how it can look if we embed events in iframes.

Unfortunately this is not dynamic. It has to be copy and pasted in each time they create an event on Eventbrite.