### PR TITLE
set posts variable to empty array when no posts in db

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -12,6 +12,9 @@ module.exports = {
   index: function(req, res){
     models.postModel.index(req,res,function(err, posts, fields){
       console.log(posts);
+      if (!posts) {
+        posts = []
+      }
       res.render("./views/admin/index.ejs", {posts:posts, errors: req.session.errors});
     });
   },


### PR DESCRIPTION
Edge case: When mySQL DB empty and no posts exist.
Issue: "posts" variable from mySQL callback is "undefined". ejs refers to an undefined "posts", causing improper display of page.
Fix: set "posts" variable when mySQL query returns "undefined" (i.e. empty set).